### PR TITLE
fix agent authorization issue

### DIFF
--- a/cmd/synclient/agents.go
+++ b/cmd/synclient/agents.go
@@ -116,11 +116,6 @@ var agentsAuthorizeCommand = &cli.Command{
 			return fmt.Errorf("site-id must be specified")
 		}
 
-		siteName := clix.String("site-name")
-		if siteName == "" {
-			return fmt.Errorf("site-name must be specified")
-		}
-
 		if err := client.AuthorizeAgent(ctx, id, name, siteID); err != nil {
 			return err
 		}

--- a/controllers/kentik_controller.go
+++ b/controllers/kentik_controller.go
@@ -122,10 +122,14 @@ func (r *KentikReconciler) Reconcile(ctx context.Context, req ctrl.Request, task
 
 		if agent.Status != synthetics.AgentStatusOK {
 			log.Info("authorizing agent", "id", agent.ID)
-			// TODO: check if already authorized and skip
+
+			site, err := synthClient.GetSite(ctx, task.Spec.KentikSite)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
 
 			// auth agent id with site
-			if err := synthClient.AuthorizeAgent(ctx, agent.ID, pod.Name, task.Spec.KentikSite); err != nil {
+			if err := synthClient.AuthorizeAgent(ctx, agent.ID, pod.Name, fmt.Sprintf("%d", site.ID)); err != nil {
 				return ctrl.Result{}, err
 			}
 			if pod.Annotations == nil {

--- a/pkg/synthetics/agents.go
+++ b/pkg/synthetics/agents.go
@@ -124,7 +124,6 @@ func (c *Client) AuthorizeAgent(ctx context.Context, agentID, agentName, siteID 
 
 		return errors.New(string(errData))
 	}
-
 	defer resp.Body.Close()
 
 	return nil


### PR DESCRIPTION
This fixes the issue where the agent authorization was using the site name instead of the site id that is needed by the syn api.